### PR TITLE
Enable meteor force-ssl package with $METEOR_SSL

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -90,6 +90,9 @@ if [ -n "${REPO}" ]; then
    cd ${METEOR_DIR}/..
 
    # Bundle the Meteor app
+   if [ -z "${METEOR_SSL}" ]; then
+     meteor remove force-ssl
+   fi
    mkdir -p ${APP_DIR}
    set +e # Allow the next command to fail
    meteor build --directory ${APP_DIR}


### PR DESCRIPTION
Changed default behavior to disable force-ssl package when using a $REPO
This was causing automatic routing to https on localhost, preventing the website to be usable
When launching from Docker add "-e METEOR_SSL=1" for example to enable force-ssl package.